### PR TITLE
Add manual Jita market refresh

### DIFF
--- a/assets/js/industry-market.js
+++ b/assets/js/industry-market.js
@@ -1,0 +1,97 @@
+(() => {
+  "use strict";
+
+  const app = document.querySelector("[data-industry-app]");
+  if (!app) return;
+
+  const pricingDetails = app.querySelector("[data-pricing-details]");
+  const pricingBody = pricingDetails?.querySelector(".planner-details-body");
+  const pricingToggle = pricingDetails?.querySelector(".pricing-toggle");
+  if (!pricingDetails || !pricingBody) return;
+
+  function resolveApiBase() {
+    const configured = document.body.dataset.industryApiBase?.trim();
+    if (configured) return configured.replace(/\/$/, "");
+    if (["127.0.0.1", "localhost"].includes(window.location.hostname)) {
+      return "http://127.0.0.1:8000";
+    }
+    return "";
+  }
+
+  const apiBase = resolveApiBase();
+  const panel = document.createElement("div");
+  panel.dataset.marketRefresh = "jita";
+
+  const age = document.createElement("span");
+  age.dataset.marketAge = "jita";
+  age.setAttribute("role", "status");
+  age.setAttribute("aria-live", "polite");
+  age.textContent = "Jita prices: checking…";
+
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "text-button";
+  button.dataset.marketRefreshButton = "jita";
+  button.textContent = "Fetch new prices";
+
+  panel.append(age, document.createTextNode(" "), button);
+  if (pricingToggle) {
+    pricingToggle.insertAdjacentElement("afterend", panel);
+  } else {
+    pricingBody.prepend(panel);
+  }
+
+  function ageLabel(snapshot) {
+    if (!snapshot || snapshot.status === "unavailable" || snapshot.age_minutes === null) {
+      return "Jita prices: unavailable";
+    }
+    const minutes = Number(snapshot.age_minutes);
+    const unit = minutes === 1 ? "minute" : "minutes";
+    const freshness = snapshot.status === "fresh" ? "current" : "stale";
+    return `Jita prices: ${minutes} ${unit} old · ${freshness}`;
+  }
+
+  async function getStatus() {
+    const response = await fetch(`${apiBase}/api/market/jita/status`, {
+      headers: { Accept: "application/json" },
+    });
+    if (!response.ok) throw new Error(`Market status failed (${response.status})`);
+    return response.json();
+  }
+
+  async function refreshPrices({ manual = false } = {}) {
+    button.disabled = true;
+    age.textContent = manual ? "Jita prices: fetching…" : "Jita prices: checking…";
+    try {
+      const response = await fetch(`${apiBase}/api/market/jita/refresh`, {
+        method: "POST",
+        headers: { Accept: "application/json" },
+      });
+      if (!response.ok) throw new Error(`Market refresh failed (${response.status})`);
+      const payload = await response.json();
+      age.textContent = ageLabel(payload.snapshot);
+      if (manual && payload.refresh_status === "fresh") {
+        age.textContent += " · already up to date";
+      } else if (manual && payload.refresh_status === "updated") {
+        age.textContent += " · updated; recalculate to apply";
+      } else if (manual && payload.refresh_status === "not_modified") {
+        age.textContent += " · no newer ESI data";
+      }
+    } catch (_error) {
+      try {
+        const snapshot = await getStatus();
+        age.textContent = `${ageLabel(snapshot)} · refresh failed`;
+      } catch (_statusError) {
+        age.textContent = "Jita prices: unavailable · refresh failed";
+      }
+    } finally {
+      button.disabled = false;
+    }
+  }
+
+  button.addEventListener("click", () => refreshPrices({ manual: true }));
+
+  // Exactly one automatic attempt per page load. There is intentionally no
+  // polling timer or heartbeat; another refresh only happens on reload or click.
+  refreshPrices();
+})();

--- a/assets/js/industry.js
+++ b/assets/js/industry.js
@@ -12,6 +12,12 @@
     const implants = document.createElement("script");
     implants.src = new URL("industry-implants.js", baseUrl).href;
     implants.async = false;
+    implants.addEventListener("load", () => {
+      const market = document.createElement("script");
+      market.src = new URL("industry-market.js", baseUrl).href;
+      market.async = false;
+      document.head.append(market);
+    });
     document.head.append(implants);
   });
   document.head.append(core);

--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -3,6 +3,7 @@ from typing import Annotated
 from fastapi import Depends
 from sqlalchemy.orm import Session
 
+from app.config import get_settings
 from app.database.repositories.industry import SqlAlchemyIndustryRepository
 from app.database.repositories.market import SqlAlchemyMarketCacheRepository
 from app.database.session import get_db_session
@@ -11,7 +12,7 @@ from app.industry.economics_service import (
     IndustryEconomicsService,
     MarketContext,
 )
-from app.config import get_settings
+from app.market.application import MarketApplicationService
 
 
 DatabaseSession = Annotated[Session, Depends(get_db_session)]
@@ -27,6 +28,15 @@ def get_market_repository(
     session: DatabaseSession,
 ) -> SqlAlchemyMarketCacheRepository:
     return SqlAlchemyMarketCacheRepository(session)
+
+
+def get_market_application_service(
+    market_repository: Annotated[
+        SqlAlchemyMarketCacheRepository,
+        Depends(get_market_repository),
+    ],
+) -> MarketApplicationService:
+    return MarketApplicationService(market_repository, get_settings())
 
 
 def get_industry_application_service(

--- a/backend/app/api/routes/market.py
+++ b/backend/app/api/routes/market.py
@@ -1,0 +1,104 @@
+from datetime import datetime
+from typing import Annotated, Literal
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from app.api.dependencies import get_market_application_service
+from app.api.schemas.industry import ApiModel
+from app.market.application import (
+    JitaRefreshView,
+    JitaSnapshotView,
+    MarketApplicationService,
+)
+from app.market.errors import (
+    EsiRateLimitError,
+    MarketCacheError,
+    MarketRefreshInProgressError,
+)
+
+
+router = APIRouter(prefix="/api/market", tags=["market"])
+MarketServiceDependency = Annotated[
+    MarketApplicationService,
+    Depends(get_market_application_service),
+]
+
+
+class JitaSnapshotResponse(ApiModel):
+    region_id: int
+    location_id: int
+    location_name: str
+    status: Literal["fresh", "stale", "unavailable"]
+    fetched_at: datetime | None
+    fresh_until: datetime | None
+    age_minutes: int | None
+    row_count: int
+
+
+class JitaRefreshResponse(ApiModel):
+    refresh_status: Literal["fresh", "updated", "not_modified"]
+    snapshot: JitaSnapshotResponse
+
+
+def _snapshot_response(view: JitaSnapshotView) -> JitaSnapshotResponse:
+    return JitaSnapshotResponse(
+        region_id=view.region_id,
+        location_id=view.location_id,
+        location_name=view.location_name,
+        status=view.status.value,
+        fetched_at=view.fetched_at,
+        fresh_until=view.fresh_until,
+        age_minutes=view.age_minutes,
+        row_count=view.row_count,
+    )
+
+
+def _refresh_response(view: JitaRefreshView) -> JitaRefreshResponse:
+    return JitaRefreshResponse(
+        refresh_status=view.refresh_status.value,
+        snapshot=_snapshot_response(view.snapshot),
+    )
+
+
+@router.get("/jita/status", response_model=JitaSnapshotResponse)
+def jita_status(service: MarketServiceDependency) -> JitaSnapshotResponse:
+    return _snapshot_response(service.jita_status())
+
+
+@router.post(
+    "/jita/refresh",
+    response_model=JitaRefreshResponse,
+    responses={
+        409: {"description": "A market refresh is already running"},
+        429: {"description": "ESI rate limit does not permit a refresh"},
+        502: {"description": "ESI market refresh failed"},
+    },
+)
+def refresh_jita_prices(service: MarketServiceDependency) -> JitaRefreshResponse:
+    try:
+        return _refresh_response(service.refresh_jita_prices())
+    except MarketRefreshInProgressError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "market_refresh_in_progress",
+                "message": str(exc),
+            },
+        ) from exc
+    except EsiRateLimitError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail={
+                "code": "esi_rate_limited",
+                "message": str(exc),
+                "retry_after_seconds": exc.retry_after_seconds,
+            },
+        ) from exc
+    except MarketCacheError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail={
+                "code": "market_refresh_failed",
+                "message": "Jita market refresh failed",
+            },
+        ) from exc

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.errors import install_error_handlers
 from app.api.routes.industry import router as industry_router
+from app.api.routes.market import router as market_router
 from app.api.specialist_skill_errors import install_specialist_skill_error_handler
 from app.config import get_settings
 from app.database.engine import is_database_available
@@ -46,6 +47,7 @@ def create_app(
         tags=["system"],
     )
     application.include_router(industry_router)
+    application.include_router(market_router)
     install_error_handlers(application)
     install_specialist_skill_error_handler(application)
     return application

--- a/backend/app/market/application.py
+++ b/backend/app/market/application.py
@@ -1,0 +1,157 @@
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from enum import StrEnum
+
+import httpx
+
+from app.config import Settings
+from app.database.engine import engine
+from app.database.repositories.market import market_refresh_lock
+from app.market.domain import RefreshStatus
+from app.market.errors import MarketRefreshInProgressError
+from app.market.esi import EsiClient
+from app.market.refresh import MarketCacheRefresher, hub_orders_resource_key
+from app.market.repository import MarketCacheRepository
+
+
+class JitaSnapshotStatus(StrEnum):
+    FRESH = "fresh"
+    STALE = "stale"
+    UNAVAILABLE = "unavailable"
+
+
+@dataclass(frozen=True, slots=True)
+class JitaSnapshotView:
+    region_id: int
+    location_id: int
+    location_name: str
+    status: JitaSnapshotStatus
+    fetched_at: datetime | None
+    fresh_until: datetime | None
+    age_minutes: int | None
+    row_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class JitaRefreshView:
+    refresh_status: RefreshStatus
+    snapshot: JitaSnapshotView
+
+
+def _aware_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        raise ValueError("market clock must return an aware datetime")
+    return value.astimezone(UTC)
+
+
+def _validate_user_agent(value: str) -> str:
+    normalized = value.strip()
+    lowered = normalized.casefold()
+    if lowered.startswith(("python/", "python-httpx/", "httpx/")):
+        raise ValueError("ESI_USER_AGENT must be application-specific")
+    if len(normalized) < 8 or "/" not in normalized:
+        raise ValueError("ESI_USER_AGENT must identify the application and version")
+    return normalized
+
+
+class MarketApplicationService:
+    """Expose Jita snapshot status and explicit on-demand refreshes.
+
+    Nothing in this service schedules work. A refresh only happens when a caller
+    invokes ``refresh_jita_prices``. The underlying refresher still honors ESI's
+    ``fresh_until`` metadata, so repeated page reloads or button clicks while the
+    current snapshot is fresh do not perform external ESI requests.
+    """
+
+    def __init__(
+        self,
+        repository: MarketCacheRepository,
+        settings: Settings,
+        *,
+        now=None,
+    ) -> None:
+        self._repository = repository
+        self._settings = settings
+        self._now = now or (lambda: datetime.now(UTC))
+
+    @property
+    def resource_key(self) -> str:
+        return hub_orders_resource_key(
+            self._settings.market_region_id,
+            self._settings.market_location_id,
+        )
+
+    def jita_status(self) -> JitaSnapshotView:
+        with self._repository.acquire_read_snapshot():
+            state = self._repository.get_resource_state(self.resource_key)
+
+        if state is None:
+            return JitaSnapshotView(
+                region_id=self._settings.market_region_id,
+                location_id=self._settings.market_location_id,
+                location_name=self._settings.market_location_name,
+                status=JitaSnapshotStatus.UNAVAILABLE,
+                fetched_at=None,
+                fresh_until=None,
+                age_minutes=None,
+                row_count=0,
+            )
+
+        now = _aware_utc(self._now())
+        fetched_at = _aware_utc(state.metadata.fetched_at)
+        fresh_until = _aware_utc(state.metadata.fresh_until)
+        age_seconds = max(0, int((now - fetched_at).total_seconds()))
+        compatibility_ok = (
+            state.metadata.requested_compatibility_date
+            == self._settings.esi_compatibility_date
+            and state.metadata.matched_compatibility_date
+            in (None, self._settings.esi_compatibility_date)
+        )
+        snapshot_status = (
+            JitaSnapshotStatus.FRESH
+            if compatibility_ok and fresh_until > now
+            else JitaSnapshotStatus.STALE
+        )
+        return JitaSnapshotView(
+            region_id=self._settings.market_region_id,
+            location_id=self._settings.market_location_id,
+            location_name=self._settings.market_location_name,
+            status=snapshot_status,
+            fetched_at=fetched_at,
+            fresh_until=fresh_until,
+            age_minutes=age_seconds // 60,
+            row_count=state.row_count,
+        )
+
+    def refresh_jita_prices(self) -> JitaRefreshView:
+        """Refresh Jita prices once if the cached ESI resource is stale.
+
+        This deliberately has no force mode. If ESI says the current snapshot is
+        still fresh, the refresher returns ``fresh`` without making HTTP calls.
+        """
+        user_agent = _validate_user_agent(self._settings.esi_user_agent)
+        with market_refresh_lock(engine) as acquired:
+            if not acquired:
+                raise MarketRefreshInProgressError(
+                    "Another market refresh is already running"
+                )
+            with httpx.Client(
+                timeout=httpx.Timeout(30.0, connect=10.0),
+                follow_redirects=False,
+            ) as http_client:
+                esi = EsiClient(
+                    http_client,
+                    base_url=self._settings.esi_base_url,
+                    compatibility_date=self._settings.esi_compatibility_date,
+                    user_agent=user_agent,
+                )
+                result = MarketCacheRefresher(
+                    self._repository,
+                    esi,
+                    region_id=self._settings.market_region_id,
+                    location_id=self._settings.market_location_id,
+                ).refresh_hub_orders()
+        return JitaRefreshView(
+            refresh_status=result.status,
+            snapshot=self.jita_status(),
+        )

--- a/backend/tests/test_market_manual_refresh.py
+++ b/backend/tests/test_market_manual_refresh.py
@@ -1,12 +1,12 @@
 from contextlib import contextmanager
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
+from pathlib import Path
 
 import httpx
 from fastapi.testclient import TestClient
 
 from app.api.dependencies import get_market_application_service
-from app.config import get_settings
 from app.market.application import (
     JitaRefreshView,
     JitaSnapshotStatus,
@@ -192,11 +192,11 @@ def test_market_api_exposes_status_and_explicit_refresh() -> None:
 
 
 def test_market_frontend_refreshes_only_on_page_load_or_button() -> None:
-    root = get_settings().model_config.get("env_file").parent.parent
-    loader = (root.parent / "assets" / "js" / "industry.js").read_text(
+    root = Path(__file__).resolve().parents[2]
+    loader = (root / "assets" / "js" / "industry.js").read_text(
         encoding="utf-8"
     )
-    script = (root.parent / "assets" / "js" / "industry-market.js").read_text(
+    script = (root / "assets" / "js" / "industry-market.js").read_text(
         encoding="utf-8"
     )
 

--- a/backend/tests/test_market_manual_refresh.py
+++ b/backend/tests/test_market_manual_refresh.py
@@ -1,0 +1,210 @@
+from contextlib import contextmanager
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+
+import httpx
+from fastapi.testclient import TestClient
+
+from app.api.dependencies import get_market_application_service
+from app.config import get_settings
+from app.market.application import (
+    JitaRefreshView,
+    JitaSnapshotStatus,
+    JitaSnapshotView,
+    MarketApplicationService,
+)
+from app.market.domain import (
+    CacheMetadata,
+    HubPrice,
+    OrderPageCache,
+    RefreshStatus,
+    ResourceState,
+)
+from app.market.esi import EsiClient
+from app.market.refresh import MarketCacheRefresher, hub_orders_resource_key
+from app.main import create_app
+
+
+NOW = datetime(2026, 8, 19, 20, 0, tzinfo=UTC)
+REGION_ID = 10_000_002
+LOCATION_ID = 60_003_760
+RESOURCE_KEY = hub_orders_resource_key(REGION_ID, LOCATION_ID)
+
+
+class FakeSettings:
+    market_region_id = REGION_ID
+    market_location_id = LOCATION_ID
+    market_location_name = "Jita IV - Moon 4 - Caldari Navy Assembly Plant"
+    esi_compatibility_date = date(2026, 8, 13)
+    esi_user_agent = "ITS-S-Test/1.0"
+    esi_base_url = "https://esi.evetech.net"
+
+
+class FakeRepository:
+    def __init__(self, state: ResourceState | None = None) -> None:
+        self.state = state
+        self.pages: dict[int, OrderPageCache] = {}
+
+    @contextmanager
+    def acquire_read_snapshot(self):
+        yield
+
+    def get_resource_state(self, resource_key: str):
+        return self.state if resource_key == RESOURCE_KEY else None
+
+    def get_order_pages(self, _region_id: int, _location_id: int):
+        return self.pages
+
+    def publish_order_snapshot(self, state, pages, _prices):
+        self.state = state
+        self.pages = {page.page: page for page in pages}
+
+
+def _metadata(*, fresh: bool) -> CacheMetadata:
+    return CacheMetadata(
+        etag='"orders-v1"',
+        last_modified_at=NOW - timedelta(minutes=4),
+        fresh_until=(
+            NOW + timedelta(minutes=1)
+            if fresh
+            else NOW - timedelta(minutes=1)
+        ),
+        fetched_at=NOW - timedelta(minutes=4, seconds=59),
+        requested_compatibility_date=date(2026, 8, 13),
+        matched_compatibility_date=date(2026, 8, 13),
+    )
+
+
+def test_market_status_reports_age_in_whole_minutes() -> None:
+    repository = FakeRepository(
+        ResourceState(RESOURCE_KEY, _metadata(fresh=True), 1234)
+    )
+    service = MarketApplicationService(
+        repository,
+        FakeSettings(),
+        now=lambda: NOW,
+    )
+
+    status = service.jita_status()
+
+    assert status.status == JitaSnapshotStatus.FRESH
+    assert status.age_minutes == 4
+    assert status.row_count == 1234
+    assert status.location_id == LOCATION_ID
+
+
+def test_market_status_reports_unavailable_without_snapshot() -> None:
+    status = MarketApplicationService(
+        FakeRepository(),
+        FakeSettings(),
+        now=lambda: NOW,
+    ).jita_status()
+
+    assert status.status == JitaSnapshotStatus.UNAVAILABLE
+    assert status.age_minutes is None
+    assert status.fetched_at is None
+    assert status.row_count == 0
+
+
+def test_fresh_jita_snapshot_makes_zero_esi_requests() -> None:
+    repository = FakeRepository(
+        ResourceState(RESOURCE_KEY, _metadata(fresh=True), 1)
+    )
+    repository.pages[1] = OrderPageCache(
+        region_id=REGION_ID,
+        location_id=LOCATION_ID,
+        page=1,
+        page_count=1,
+        metadata=_metadata(fresh=True),
+        quotes=(HubPrice(34, Decimal("5.00"), 10, None, None),),
+    )
+    calls = 0
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(500)
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    try:
+        esi = EsiClient(
+            client,
+            base_url="https://esi.evetech.net",
+            compatibility_date=date(2026, 8, 13),
+            user_agent="ITS-S-Test/1.0",
+            now=lambda: NOW,
+        )
+        result = MarketCacheRefresher(
+            repository,
+            esi,
+            region_id=REGION_ID,
+            location_id=LOCATION_ID,
+        ).refresh_hub_orders()
+    finally:
+        client.close()
+
+    assert result.status == RefreshStatus.FRESH
+    assert calls == 0
+
+
+class FakeMarketApplicationService:
+    def __init__(self) -> None:
+        self.refresh_calls = 0
+        self.snapshot = JitaSnapshotView(
+            region_id=REGION_ID,
+            location_id=LOCATION_ID,
+            location_name=FakeSettings.market_location_name,
+            status=JitaSnapshotStatus.FRESH,
+            fetched_at=NOW - timedelta(minutes=3),
+            fresh_until=NOW + timedelta(minutes=2),
+            age_minutes=3,
+            row_count=987,
+        )
+
+    def jita_status(self) -> JitaSnapshotView:
+        return self.snapshot
+
+    def refresh_jita_prices(self) -> JitaRefreshView:
+        self.refresh_calls += 1
+        return JitaRefreshView(RefreshStatus.FRESH, self.snapshot)
+
+
+def test_market_api_exposes_status_and_explicit_refresh() -> None:
+    application = create_app(cors_origins=())
+    fake_service = FakeMarketApplicationService()
+    application.dependency_overrides[get_market_application_service] = (
+        lambda: fake_service
+    )
+
+    with TestClient(application) as client:
+        status_response = client.get("/api/market/jita/status")
+        refresh_response = client.post("/api/market/jita/refresh")
+
+    application.dependency_overrides.clear()
+
+    assert status_response.status_code == 200
+    assert status_response.json()["age_minutes"] == 3
+    assert status_response.json()["status"] == "fresh"
+    assert refresh_response.status_code == 200
+    assert refresh_response.json()["refresh_status"] == "fresh"
+    assert refresh_response.json()["snapshot"]["row_count"] == 987
+    assert fake_service.refresh_calls == 1
+
+
+def test_market_frontend_refreshes_only_on_page_load_or_button() -> None:
+    root = get_settings().model_config.get("env_file").parent.parent
+    loader = (root.parent / "assets" / "js" / "industry.js").read_text(
+        encoding="utf-8"
+    )
+    script = (root.parent / "assets" / "js" / "industry-market.js").read_text(
+        encoding="utf-8"
+    )
+
+    assert "industry-market.js" in loader
+    assert "/api/market/jita/refresh" in script
+    assert "/api/market/jita/status" in script
+    assert "Fetch new prices" in script
+    assert 'button.addEventListener("click"' in script
+    assert "refreshPrices();" in script
+    assert "setInterval" not in script
+    assert "setTimeout" not in script


### PR DESCRIPTION
Validated manual Jita market refresh implementation. Full backend CI passed (232 tests). The tested head was fast-forwarded into `indy-calc`; no merge into `develop` was performed.